### PR TITLE
Feature/11 reservation

### DIFF
--- a/src/main/java/com/example/buserve/src/bus/controller/BusController.java
+++ b/src/main/java/com/example/buserve/src/bus/controller/BusController.java
@@ -19,11 +19,6 @@ public class BusController {
 
     private final BusService busService;
 
-    @ExceptionHandler(Exception.class)
-    public ApiResponse<?> handleIllegalArgumentException(IllegalArgumentException e) {
-        return ApiResponse.error(ApiResponseStatus.REQUEST_ERROR);
-    }
-
     // 버스 좌석 리스트 조회
     @ApiOperation(value = "버스 좌석 리스트 조회", notes = "해당 버스의 좌석 리스트를 조회한다.")
     @GetMapping("/buses/{bus_id}/seats")

--- a/src/main/java/com/example/buserve/src/common/ApiResponseStatus.java
+++ b/src/main/java/com/example/buserve/src/common/ApiResponseStatus.java
@@ -30,6 +30,14 @@ public enum ApiResponseStatus {
     POST_USERS_INVALID_EMAIL(false, 2016, "이메일 형식을 확인해주세요."),
     POST_USERS_EXISTS_EMAIL(false,2017,"중복된 이메일입니다."),
 
+    USER_NOT_FOUND(false, 2020, "사용자를 찾을 수 없습니다."),
+    SEAT_NOT_FOUND(false, 2021, "좌석을 찾을 수 없습니다."),
+    SEAT_ALREADY_RESERVED(false, 2022, "이미 예약된 좌석입니다."),
+    STOP_NOT_FOUND(false, 2023, "정류장을 찾을 수 없습니다."),
+    DUPLICATE_RESERVATION(false, 2024, "이미 해당 시간에 예약이 있습니다."),
+    RESERVATION_RESTRICTED(false, 2025, "노쇼로 인한 예약 제한 중입니다."),
+    RESERVATION_NOT_FOUND(false, 2026, "예약을 찾을 수 없습니다."),
+    UNAUTHORIZED_ACCESS(false, 2027, "권한이 없는 접근입니다."),
 
 
     /**

--- a/src/main/java/com/example/buserve/src/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/buserve/src/common/GlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.example.buserve.src.common;
+
+import com.example.buserve.src.common.exception.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleUserNotFoundException(Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(ApiResponseStatus.USER_NOT_FOUND));
+    }
+
+    @ExceptionHandler(SeatNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleSeatNotFoundException(Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(ApiResponseStatus.SEAT_NOT_FOUND));
+    }
+
+    @ExceptionHandler(SeatAlreadyReservedException.class)
+    public ResponseEntity<ApiResponse<?>> handleSeatAlreadyReservedException(Exception e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(ApiResponseStatus.SEAT_ALREADY_RESERVED));
+    }
+
+    @ExceptionHandler(StopNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleStopNotFoundException(Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(ApiResponseStatus.STOP_NOT_FOUND));
+    }
+
+    @ExceptionHandler(DuplicateReservationException.class)
+    public ResponseEntity<ApiResponse<?>> handleDuplicateReservationException(Exception e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.error(ApiResponseStatus.DUPLICATE_RESERVATION));
+    }
+
+    @ExceptionHandler(ReservationRestrictionException.class)
+    public ResponseEntity<ApiResponse<?>> handleReservationRestrictionException(Exception e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.error(ApiResponseStatus.RESERVATION_RESTRICTED));
+    }
+
+    @ExceptionHandler(ReservationNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleReservationNotFoundException(Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(ApiResponseStatus.RESERVATION_NOT_FOUND));
+    }
+
+    @ExceptionHandler(UnauthorizedAccessException.class)
+    public ResponseEntity<ApiResponse<?>> handleUnauthorizedAccessException(Exception e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error(ApiResponseStatus.UNAUTHORIZED_ACCESS));
+    }
+
+    // 기타 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        return ResponseEntity.badRequest().body(ApiResponse.error(ApiResponseStatus.REQUEST_ERROR));
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/DuplicateReservationException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/DuplicateReservationException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class DuplicateReservationException extends RuntimeException {
+    public DuplicateReservationException() {
+        super("이미 해당 시간에 예약이 있습니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/InsufficientBusMoneyException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/InsufficientBusMoneyException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class InsufficientBusMoneyException extends RuntimeException {
+    public InsufficientBusMoneyException() {
+        super("버정머니가 부족합니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/ReservationNotFoundException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/ReservationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class ReservationNotFoundException extends RuntimeException{
+    public ReservationNotFoundException() {
+        super("예약을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/ReservationRestrictionException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/ReservationRestrictionException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class ReservationRestrictionException extends RuntimeException {
+    public ReservationRestrictionException() {
+        super("노쇼로 인한 예약 제한 중입니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/SeatAlreadyReservedException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/SeatAlreadyReservedException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class SeatAlreadyReservedException extends RuntimeException{
+    public SeatAlreadyReservedException() {
+        super("이미 예약된 좌석입니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/SeatNotFoundException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/SeatNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class SeatNotFoundException extends RuntimeException {
+    public SeatNotFoundException() {
+        super("좌석을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/StopNotFoundException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/StopNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class StopNotFoundException extends RuntimeException{
+    public StopNotFoundException() {
+        super("정류장을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/UnauthorizedAccessException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/UnauthorizedAccessException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class UnauthorizedAccessException extends RuntimeException {
+    public UnauthorizedAccessException() {
+        super("접근 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/common/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/buserve/src/common/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.buserve.src.common.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException() {
+        super("사용자를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/example/buserve/src/pay/controller/BusMoneyController.java
+++ b/src/main/java/com/example/buserve/src/pay/controller/BusMoneyController.java
@@ -22,11 +22,6 @@ public class BusMoneyController {
         this.userService = userService;
     }
 
-    @ExceptionHandler(Exception.class)
-    public ApiResponse<?> handleIllegalArgumentException(IllegalArgumentException e) {
-        return ApiResponse.error(ApiResponseStatus.REQUEST_ERROR);
-    }
-
     @ApiOperation(value = "사용자의 버스머니 조회 API")
     @GetMapping
     public ApiResponse<AmountDto> getBusMoney(Principal principal) {

--- a/src/main/java/com/example/buserve/src/pay/controller/ChargingMethodController.java
+++ b/src/main/java/com/example/buserve/src/pay/controller/ChargingMethodController.java
@@ -25,11 +25,6 @@ public class ChargingMethodController {
         this.chargingMethodService = chargingMethodService;
     }
 
-    @ExceptionHandler(Exception.class)
-    public ApiResponse<?> handleIllegalArgumentException(IllegalArgumentException e) {
-        return ApiResponse.error(ApiResponseStatus.REQUEST_ERROR);
-    }
-
     @ApiOperation(value = "사용자의 전체 충전수단 조회 API")
     @GetMapping
     public ApiResponse<List<ChargingMethodInfoDto>> getAllChargingMethods(Principal principal) {

--- a/src/main/java/com/example/buserve/src/reservation/controller/ReservationController.java
+++ b/src/main/java/com/example/buserve/src/reservation/controller/ReservationController.java
@@ -1,7 +1,6 @@
 package com.example.buserve.src.reservation.controller;
 
 import com.example.buserve.src.common.ApiResponse;
-import com.example.buserve.src.common.ApiResponseStatus;
 import com.example.buserve.src.reservation.dto.ReservationRequestDto;
 import com.example.buserve.src.reservation.dto.ReservationResponseDto;
 import com.example.buserve.src.reservation.service.ReservationService;
@@ -21,11 +20,6 @@ import java.util.List;
 public class ReservationController {
 
     private final ReservationService reservationService;
-
-    @ExceptionHandler(Exception.class)
-    public ApiResponse<?> handleException(Exception e) {
-        return ApiResponse.error(ApiResponseStatus.REQUEST_ERROR);
-    }
 
     @ApiOperation(value = "예약 내역 조회", notes = "사용자의 예약 내역을 최근순으로 조회한다.")
     @GetMapping

--- a/src/main/java/com/example/buserve/src/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/buserve/src/reservation/service/ReservationService.java
@@ -5,6 +5,7 @@ import com.example.buserve.src.bus.entity.Stop;
 import com.example.buserve.src.bus.repository.RouteStopRepository;
 import com.example.buserve.src.bus.repository.SeatRepository;
 import com.example.buserve.src.bus.repository.StopRepository;
+import com.example.buserve.src.common.exception.*;
 import com.example.buserve.src.reservation.dto.ReservationRequestDto;
 import com.example.buserve.src.reservation.dto.ReservationResponseDto;
 import com.example.buserve.src.reservation.entity.Reservation;
@@ -34,7 +35,6 @@ public class ReservationService {
     private final UserRepository userRepository;
     private final SeatRepository seatRepository;
     private final StopRepository stopRepository;
-    private final RouteStopRepository routeStopRepository;
 
     public List<ReservationResponseDto> getReservations(Long userId) {
         List<Reservation> reservations = reservationRepository.findAllByUserId(userId);
@@ -52,7 +52,7 @@ public class ReservationService {
 
     @Transactional
     public ReservationResponseDto createReservation(Long userId, ReservationRequestDto requestDto) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         applyNoShowPenaltyIfNeeded(user);
 
         // 버정머니 확인
@@ -60,20 +60,20 @@ public class ReservationService {
             throw new IllegalArgumentException("버정머니가 부족합니다.");
         }
 
-        Seat seat = seatRepository.findById(requestDto.getSeatId()).orElseThrow(() -> new IllegalArgumentException("좌석을 찾을 수 없습니다."));
+        Seat seat = seatRepository.findById(requestDto.getSeatId()).orElseThrow(SeatNotFoundException::new);
 
         // 좌석 예약 가능 여부 확인
         if (!seat.isAvailable()) {
-            throw new IllegalArgumentException("이미 예약된 좌석입니다.");
+            throw new SeatAlreadyReservedException();
         }
 
-        Stop stop = stopRepository.findById(requestDto.getStopId()).orElseThrow(() -> new IllegalArgumentException("정류장을 찾을 수 없습니다."));
+        Stop stop = stopRepository.findById(requestDto.getStopId()).orElseThrow(StopNotFoundException::new);
         LocalDateTime expectedArrivalTime = convertToExpectedArrivalTime(requestDto.getExpectedArrivalTime());
 
         // 사용자가 해당 시간에 이미 예약한 내역이 있는지 확인
         List<Reservation> userReservations = reservationRepository.findAllByUserAndExpectedArrivalTime(user, expectedArrivalTime);
         if (!userReservations.isEmpty()) {
-            throw new IllegalArgumentException("이미 해당 시간에 예약이 있습니다.");
+            throw new DuplicateReservationException();
         }
 
         // 버정머니 차감
@@ -111,7 +111,7 @@ public class ReservationService {
             LocalDateTime now = LocalDateTime.now();
             LocalDateTime penaltyEndDate = user.getNoShowPenaltyDate().plusDays(7);
             if (now.isBefore(penaltyEndDate)) {
-                throw new IllegalArgumentException("노쇼로 인한 예약 제한 중입니다.");
+                throw new ReservationRestrictionException();
             }
         }
     }
@@ -124,9 +124,9 @@ public class ReservationService {
     }
 
     public ReservationResponseDto getReservationDetail(Long userId, Long reservationId) {
-        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
+        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(ReservationNotFoundException::new);
         if (!reservation.getUser().getId().equals(userId)) {
-            throw new IllegalArgumentException("예약을 찾을 수 없습니다.");
+            throw new UnauthorizedAccessException();
         }
         return new ReservationResponseDto(
                 reservation.getSeat().getBus().getRoute().getRouteName(),
@@ -138,9 +138,9 @@ public class ReservationService {
     }
 
     public ReservationResponseDto completeBoarding(Long userId, Long reservationId) {
-        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
+        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(ReservationNotFoundException::new);
         if (!reservation.getUser().getId().equals(userId)) {
-            throw new IllegalArgumentException("예약을 찾을 수 없습니다.");
+            throw new UnauthorizedAccessException();
         }
         reservation.completeBoarding();
         reservationRepository.save(reservation);


### PR DESCRIPTION
## :white_check_mark: 해결한 이슈
close #15 

## :memo: 요약
- 글로벌 에러 핸들러 구현
- 사용자 정의 예외 추가
- 예외마다 API 응답 메시지 추가
## :book: 설명
- 기존에 각 컨트롤러마다 예외핸들러를 두어 에러를 처리했는데 한 번에 처리할 수 있도록 글로벌 에러 핸들러를 구현하였다.
- API 호출 시에 에러가 발생한 경우 원인을 알 수 있게 에러 별로 메시지를 구현하였다.
## :camera: 스크린샷(옵션)
### 존재하지 않는 예약 ID를 입력한 경우
![image](https://github.com/BUSERVE/buserve-server/assets/55042337/1ea3416e-c800-40f4-9a4c-f79e62cd8aba)
### 추가한 사용자 정의 예외
![image](https://github.com/BUSERVE/buserve-server/assets/55042337/8b2211cf-f80c-458a-8825-0bd50d1f8f20)
### 예외 메시지 추가
![image](https://github.com/BUSERVE/buserve-server/assets/55042337/acdaa702-74c8-49d5-8c69-dd1ed8917929)

## :clipboard: 체크 리스트
- [X] 이슈 번호를 기입하셨나요?
- [X] 컨벤션을 지키셨나요?
